### PR TITLE
Wiremock configuration syntax changed

### DIFF
--- a/StoryLine.Wiremock.Tests/SyntaxTests.cs
+++ b/StoryLine.Wiremock.Tests/SyntaxTests.cs
@@ -14,20 +14,18 @@ namespace StoryLine.Wiremock.Tests
             Scenario.New()
                 .When()
                     .Performs<MockHttpRequest>(x => x
-                        .Request()
+                        .Request(req => req
                             .Path()
                                 .EqualsTo("/xxx")
-                            .Method("GET")
-                        .Response()
+                                .Method("GET"))
+                        .Response(res => res
                             .Status(200)
-                            .Body("Text")
-                        )
+                            .Body("Text")))
                 .Then()
                     .Expects<HttpRequestMock>(x => x
-                        .Request()
-                            .Path(p => p.EqualsTo("/dragon"))
-                        .Called()
-                            .AtLeastOnce())
+                        .Request(req => req
+                            .Path(p => p.EqualsTo("/dragon")))
+                        .Called(c => c.AtLeastOnce()))
                 .Run();
 
 

--- a/StoryLine.Wiremock/Actions/MockHttpRequest.cs
+++ b/StoryLine.Wiremock/Actions/MockHttpRequest.cs
@@ -1,20 +1,38 @@
-﻿using StoryLine.Contracts;
+﻿using System;
+using StoryLine.Contracts;
 using StoryLine.Wiremock.Builders;
 
 namespace StoryLine.Wiremock.Actions
 {
     public class MockHttpRequest : IActionBuilder
     {
-        private readonly IApiStubState _apiStubState = new ApiStubState();
+        private Action<RequestBuilder> _requestConfig = req => req.Method("GET").Path(x => x.EqualsTo("/"));
+        private Action<ResponseBuilder> _responseConfig = res => res.Body("Ok").Status(200);
 
         IAction IActionBuilder.Build()
         {
-            return new MockHttpRequestAction(_apiStubState);
+            var apiStubState = new ApiStubState();
+            var requestBuilder = new RequestBuilder(apiStubState);
+            _requestConfig(requestBuilder);
+
+            var responseBuilder = new ResponseBuilder(apiStubState);
+            _responseConfig(responseBuilder);
+
+            return new MockHttpRequestAction(apiStubState);
         }
 
-        public RequestBuilder Request()
+        public MockHttpRequest Request(Action<RequestBuilder> requestConfig)
         {
-            return new RequestBuilder(_apiStubState);
+            _requestConfig = requestConfig ?? throw new ArgumentNullException(nameof(requestConfig));
+
+            return this;
+        }
+
+        public MockHttpRequest Response(Action<ResponseBuilder> responseConfig)
+        {
+            _responseConfig = responseConfig ?? throw new ArgumentNullException(nameof(responseConfig));
+
+            return this;
         }
     }
 }

--- a/StoryLine.Wiremock/Builders/RequestBuilder.cs
+++ b/StoryLine.Wiremock/Builders/RequestBuilder.cs
@@ -45,15 +45,6 @@ namespace StoryLine.Wiremock.Builders
             return path(new PathBuilder(State));
         }
 
-        public ResponseBuilder Response()
-        {
-            return new ResponseBuilder(State);
-        }
-
-        public RequestCountBuilder Called()
-        {
-            return new RequestCountBuilder(State);
-        }
 
         public HeaderBuilder Header(string key)
         {

--- a/StoryLine.Wiremock/Expectations/HttpRequestMock.cs
+++ b/StoryLine.Wiremock/Expectations/HttpRequestMock.cs
@@ -1,20 +1,38 @@
-﻿using StoryLine.Contracts;
+﻿using System;
+using StoryLine.Contracts;
 using StoryLine.Wiremock.Builders;
 
 namespace StoryLine.Wiremock.Expectations
 {
     public class HttpRequestMock : IExpectationBuilder
     {
-        private readonly IApiStubState _state = new ApiStubState();
+        private Action<RequestBuilder> _requestConfig = req => req.Method("GET").Path(x => x.EqualsTo("/"));
+        private Action<RequestCountBuilder> _requestCountConfig = c => c.AtLeastOnce();
 
-        public RequestBuilder Request()
+        public HttpRequestMock Request(Action<RequestBuilder> requestConfig)
         {
-            return new RequestBuilder(_state);
+            _requestConfig = requestConfig ?? throw new ArgumentNullException(nameof(requestConfig));
+
+            return this;
+        }
+
+        public HttpRequestMock Called(Action<RequestCountBuilder> requestCountConfig)
+        {
+            _requestCountConfig = requestCountConfig ?? throw new ArgumentNullException(nameof(requestCountConfig));
+
+            return this;
         }
 
         IExpectation IExpectationBuilder.Build()
         {
-            return new HttpRequestMockExpectation(_state);
+            var state = new ApiStubState();
+            var requestBuilder = new RequestBuilder(state);
+            _requestConfig(requestBuilder);
+
+            var requestCountBuilder = new RequestCountBuilder(state);
+            _requestCountConfig(requestCountBuilder);
+
+            return new HttpRequestMockExpectation(state);
         }
     }
 }

--- a/StoryLine.Wiremock/StoryLine.Wiremock.csproj
+++ b/StoryLine.Wiremock/StoryLine.Wiremock.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.7</Version>
+    <Version>1.1.0</Version>
     <PackageLicenseUrl>https://github.com/DiamondDragon/StoryLine.Wiremock/blob/master/License.txt</PackageLicenseUrl>
     <Copyright>Andrei Salanoi &lt;diamond_dragon@tut.by&gt;</Copyright>
     <PackageProjectUrl>https://github.com/DiamondDragon/StoryLine.Wiremock</PackageProjectUrl>


### PR DESCRIPTION
* Syntax of Wiremock configuration was updated. As result not applicable configuration is no longer possible.